### PR TITLE
fix: properly parse empty messages in options (#1429)

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -555,7 +555,7 @@ function parse(source, root, options) {
 
     function parseOptionValue(parent, name) {
         if (skip("{", true)) { // { a: "foo" b { c: "bar" } }
-            do {
+            while (!skip("}", true)) {
                 /* istanbul ignore if */
                 if (!nameRe.test(token = next()))
                     throw illegal(token, "name");
@@ -570,7 +570,7 @@ function parse(source, root, options) {
                         setOption(parent, name + "." + token, readValue(true));
                 }
                 skip(",", true);
-            } while (!skip("}", true));
+            }
         } else
             setOption(parent, name, readValue(true));
         // Does not enforce a delimiter to be universal

--- a/tests/data/uncommon.proto
+++ b/tests/data/uncommon.proto
@@ -31,6 +31,8 @@ message Test2 {
 
     map<uint64,Test> longmap = 10;
 
+    int32 optionTest = 11 [(my_options) = { a: "foo" b {} }];
+
     /** pre */
     oneof kind;
     oneof kind2; /// post


### PR DESCRIPTION
* Properly parse empty messages in options

* Add missing semicolon in test